### PR TITLE
Properly unique text ids across rounds 1 and 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,7 @@ dmypy.json
 # Custom
 
 dynasent-v1/*
+dynasent-v1.1/*
 img/*
 !img/.keepdir
 

--- a/README.md
+++ b/README.md
@@ -28,23 +28,23 @@ DynaSent is an English-language benchmark task for ternary (positive/negative/ne
 
 ## Dataset files
 
-The dataset is [dynasent-v1.zip](dynasent-v1.zip), which is included in this repository.
+The dataset is [dynasent-v1.1.zip](dynasent-v1.1.zip), which is included in this repository. `v1.1` differs from `v1` only in that `v1.1` has proper unique ids for Round 1 and corrects a bug that led to some non-unique ids in Round 2. There are no changes to the examples or other metadata.
 
 The dataset consists of two rounds, each with a train/dev/test split:
 
 
 ### Round 1: Naturally occurring sentences
 
-* `dynasent-v1-round01-yelp-train.jsonl`
-* `dynasent-v1-round01-yelp-dev.jsonl`
-* `dynasent-v1-round01-yelp-test.jsonl`
+* `dynasent-v1.1-round01-yelp-train.jsonl`
+* `dynasent-v1.1-round01-yelp-dev.jsonl`
+* `dynasent-v1.1-round01-yelp-test.jsonl`
 
 
 ### Round 1: Sentences crowdsourced using Dynabench
 
-* `dynasent-v1-round02-dynabench-train.jsonl`
-* `dynasent-v1-round02-dynabench-dev.jsonl`
-* `dynasent-v1-round02-dynabench-test.jsonl`
+* `dynasent-v1.1-round02-dynabench-train.jsonl`
+* `dynasent-v1.1-round02-dynabench-dev.jsonl`
+* `dynasent-v1.1-round02-dynabench-test.jsonl`
 
 
 ### SST-dev revalidation
@@ -77,7 +77,7 @@ For example, to create a Round 1 train set restricting to examples with ternary 
 ```python
 import os
 
-r1_train_filename = os.path.join('dynasent-v1', 'dynasent-v1-round01-yelp-train.jsonl')
+r1_train_filename = os.path.join('dynasent-v1.1', 'dynasent-v1.1-round01-yelp-train.jsonl')
 
 ternary_labels = ('positive', 'negative', 'neutral')
 
@@ -98,7 +98,8 @@ X_train, y_train = zip(*[(d['sentence'], d['gold_label']) for d in r1_train])
  'model_0_probs': {'negative': 0.01173639390617609,
   'positive': 0.7473671436309814,
   'neutral': 0.24089649319648743},
- 'text_id': 'IDHkeGo-nxhqX4Exkdr08A',
+ 'text_id': 'r1-0000001',
+ 'review_id': 'IDHkeGo-nxhqX4Exkdr08A', 
  'review_rating': 1,
  'label_distribution': {'positive': ['w130', 'w186', 'w207', 'w264', 'w54'],
   'negative': [],
@@ -114,7 +115,8 @@ Details:
 * `'indices_into_review_text':` indices of `'sentence'` into the original review in the [Yelp Academic Dataset](https://www.yelp.com/dataset).
 * `'model_0_label'`: prediction of Model 0 as described in the paper. The possible values are `'positive'`, `'negative'`, and `'neutral'`.
 * `'model_0_probs'`: probability distribution predicted by Model 0. The keys are `('positive', 'negative', 'neutral')` and the values are floats.
-* `'text_id'`: review-level identifier for the review from the [Yelp Academic Dataset](https://www.yelp.com/dataset) containing `'sentence'`.
+* `'text_id'`: unique identifier for this entry.
+* `'review_id'`: review-level identifier for the review from the [Yelp Academic Dataset](https://www.yelp.com/dataset) containing `'sentence'`.
 * `'review_rating'`: review-level star-rating for the review containing `'sentence'` in the [Yelp Academic Dataset](https://www.yelp.com/dataset). The possible values are `1`, `2`, `3`, `4`, and `5`.
 * `'label_distribution':` response distribution from the MTurk validation task. The keys are `('positive', 'negative', 'neutral')` and the values are lists of anonymized MTurk ids, which are used consistently throughout the dataset.
 * `'gold_label'`: the label chosen by at least three of the five workers if there is one (possible values: `'positive'`, `'negative'`, '`neutral'`, and `'mixed'`), else `None`. 
@@ -159,7 +161,7 @@ def add_review_text_round1(dataset, yelp_index):
  'model_1_probs': {'negative': 0.29140257835388184,
   'positive': 0.6788994669914246,
   'neutral': 0.029697999358177185},
- 'text_id': 'd16069',
+ 'text_id': 'r2-0000001',
  'label_distribution': {'positive': ['w43', 'w26', 'w155', 'w23'],
   'negative': [],
   'neutral': [],
@@ -259,7 +261,7 @@ import os
 from sklearn.metrics import classification_report
 from dynasent_models import DynaSentModel
 
-dev_filename = os.path.join('dynasent-v1', 'dynasent-v1-round02-dynabench-dev.jsonl')
+dev_filename = os.path.join('dynasent-v1.1', 'dynasent-v1.1-round02-dynabench-dev.jsonl')
 
 dev = load_dataset(dev_filename)
 

--- a/test_dataset.py
+++ b/test_dataset.py
@@ -9,15 +9,15 @@ from dynasent_utils import load_dataset
 __author__ = 'Christopher Potts'
 
 
-src_dirname = 'dynasent-v1'
+src_dirname = 'dynasent-v1.1'
 
 r1_filename_template = os.path.join(
     src_dirname,
-    'dynasent-v1-round01-yelp-{}.jsonl')
+    'dynasent-v1.1-round01-yelp-{}.jsonl')
 
 r2_filename_template = os.path.join(
     src_dirname,
-    'dynasent-v1-round02-dynabench-{}.jsonl')
+    'dynasent-v1.1-round02-dynabench-{}.jsonl')
 
 sst_filename = os.path.join(
     src_dirname,
@@ -137,7 +137,6 @@ def _is_our_anonymized_mturk_id(s):
     return s.startswith("w") and not any(c.isupper() for c in s)
 
 
-
 @pytest.mark.parametrize('split', [
     'r2_train',
     'r2_dev',
@@ -174,3 +173,10 @@ def test_no_round2_assess_set_repeated_prompts(dataset):
         for d in dataset[split]:
             prompt_sentence = d['prompt_data']['prompt_sentence']
             assert len(all_prompts[prompt_sentence]) == 1
+
+
+def test_unique_ids(dataset):
+    all_ids = []
+    for split, exs in dataset.items():
+        all_ids += [d['text_id'] for d in exs]
+    assert len(all_ids) == len(set(all_ids))


### PR DESCRIPTION
This is a proposal for creating proper unique `text_id` values in rounds 1 and 2. It's a response to two issues we noticed:

1. Round 1 didn't have unique identifiers. While the `sentence` value itself can function as a unique identifier, this doesn't seems optimal.
2. Round 2's identifiers were not in fact unique due to overlooked issues in the underlying database. This PR corrects that by creating new sequential identifiers.

Nothing about the examples or other metadata is affected by this proposal. It's really just to make life easier for people who need these unique identifiers. The version change (to `v1.1`) seems smart some values do change in the data.